### PR TITLE
speedup: count-lines instead of substracting line-number-at-pos's

### DIFF
--- a/evil-goggles.el
+++ b/evil-goggles.el
@@ -136,7 +136,7 @@ background of 'evil-goggles-default-face, then 'region."
        (numberp end)
        ;; don't show overlay if the region is a single char on a single line
        (not (and (<= (- end beg) 1)
-                 (= (line-number-at-pos beg) (line-number-at-pos end))))
+                 (<= (count-lines beg end) 1)))
        (<= (point-min) beg end)
        (>= (point-max) end beg)
        (not (evil-visual-state-p))
@@ -415,7 +415,7 @@ BEG and END are the argumenets to the original functions."
   (when (and (called-interactively-p 'interactive)
              (evil-goggles--show-p beg end)
              ;; don't show goggles for single lines ("J"/"gJ" without count)
-             (< 1 (- (line-number-at-pos end) (line-number-at-pos beg))))
+             (< 1 (count-lines beg end)))
     (evil-goggles--show-blocking-hint beg end)))
 
 ;;; fill


### PR DESCRIPTION
Before this change, doing a simple `x` on line 144213 of a big file
would make line-number-at-pos count lines from point-min, taking
several seconds on my machine. Since we're looking for both beg and
end (which happen to be one character apart), this counts all 144213
lines twice. The count-lines function instead narrows the buffer
first, eradicating the slowdown.

(See
https://bitbucket.org/lyro/evil/pull-requests/32/count-lines-much-faster-than-subtracting/diff
which regards a similar change to evil.)