### PR TITLE
Support users who prefer to manually enable Evil on a per-buffer basis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .elpa/
 *.elc
 test/evil-tests.el
+test/evil-test-helpers.el
 makel.mk

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Space-separated list of the dependencies of your project (include
 # package-lint and/or buttercup if you want makel to use these tools):
-ELPA_DEPENDENCIES=evil evil-test-helpers package-lint
+ELPA_DEPENDENCIES=evil package-lint
 
 # List of package archives to download above dependencies
 # from. Available archives are: gnu, melpa, melpa-stable and org:
@@ -20,6 +20,7 @@ LINT_COMPILE_FILES=${LINT_CHECKDOC_FILES}
 
 test/evil-tests.el:
 	curl -s "https://raw.githubusercontent.com/emacs-evil/evil/master/evil-tests.el" --output test/evil-tests.el
+	curl -s "https://raw.githubusercontent.com/emacs-evil/evil/master/evil-test-helpers.el" --output test/evil-test-helpers.el
 
 makel.mk:
 	# Download makel

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ makel.mk:
 		curl \
 		--fail --silent --show-error --insecure --location \
 		--retry 9 --retry-delay 9 \
-		-O https://gitlab.petton.fr/DamienCassou/makel/raw/v0.6.0/makel.mk; \
+		-O https://gitea.petton.fr/DamienCassou/makel/raw/tag/v0.6.0/makel.mk; \
 	fi
 
 # Include makel.mk if present

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ LINT_PACKAGE_LINT_FILES=$(wildcard *.el)
 LINT_COMPILE_FILES=${LINT_CHECKDOC_FILES}
 
 test/evil-tests.el:
-	curl -s "https://raw.githubusercontent.com/emacs-evil/evil/40daccf17685ba4e59cf56563a8b0c4a386e109c/evil-tests.el" --output test/evil-tests.el
+	curl -s "https://raw.githubusercontent.com/emacs-evil/evil/master/evil-tests.el" --output test/evil-tests.el
 
 makel.mk:
 	# Download makel

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ evil-goggles-record-macro-face
 
 ## NEWS - Recent Significant Changes
 
+- [Oct 01, 2020] Add support for `evil-local-mode`
 - [Jul 01, 2018] Make async hint cleanup more robust
 - [Jun 01, 2018] Refactor code to not use :around advice-s, which was a source of edge-case-issues
 - [Feb 05, 2018] Show hint on start/stop macro recording

--- a/evil-goggles.el
+++ b/evil-goggles.el
@@ -287,7 +287,7 @@ regardless of the value of `evil-this-type'."
       (evil-goggles--show-overlay beg end face dur))))
 
 (defun evil-goggles--generic-blocking-advice (beg end &rest _)
-  "Advice for interactive functions, show a blocing hint.
+  "Advice for interactive functions, show a blocking hint.
 
 This function is intended to be used as advice for interactive funs
 which take BEG and END as their first and second arguments."

--- a/evil-goggles.el
+++ b/evil-goggles.el
@@ -131,7 +131,7 @@ background of 'evil-goggles-default-face, then 'region."
 (defun evil-goggles--show-p (beg end)
   "Return t if the overlay should be displayed in region BEG to END."
   (and (not evil-inhibit-operator-value)
-       (bound-and-true-p evil-mode)
+       (bound-and-true-p evil-local-mode)
        (numberp beg)
        (numberp end)
        ;; don't show overlay if the region is a single char on a single line

--- a/test/evil-goggles-test.el
+++ b/test/evil-goggles-test.el
@@ -1,4 +1,9 @@
 
+(let ((current-directory (file-name-directory load-file-name)))
+  (setq evil-goggles-test-path (expand-file-name "." current-directory)))
+
+(add-to-list 'load-path evil-goggles-test-path) ;; so evil-test-helpers can be loaded below
+
 (require 'ert)
 (require 'evil)
 (require 'evil-goggles)


### PR DESCRIPTION
Support users who prefer to manually enable `evil-local-mode` on a per-buffer basis (vs. enabling Evil in all buffers via the global `evil-mode`). This should be a safe change because the global `evil-mode` automatically enables the buffer-local one in all covered buffers, too.

Update stale Makefile and tests.

Thanks for this awesome package 🙇 🎉 