### PR TITLE
Bump version to 0.0.2 for NonGNU ELPA

### DIFF
--- a/evil-goggles.el
+++ b/evil-goggles.el
@@ -5,7 +5,7 @@
 ;; Author: edkolev <evgenysw@gmail.com>
 ;; URL: http://github.com/edkolev/evil-goggles
 ;; Package-Requires: ((emacs "24.4") (evil "1.0.0"))
-;; Version: 0.0.1
+;; Version: 0.0.2
 ;; Keywords: emulations, evil, vim, visual
 
 ;; This file is NOT part of GNU Emacs.


### PR DESCRIPTION
Hi!

I am investigating if we could add this package to [NonGNU ELPA](http://elpa.nongnu.org/) (see link), a new Emacs Lisp package archive that will be enabled by default in Emacs 28. This means that users of that version or later will be able to install this package without any configuration: they can just run `M-x list-packages` and install it out of the box. We hope that this will improve Emacs and help bring new users to this package and others.

The main difference between NonGNU ELPA and MELPA is that only stable versions of packages are released. A new release will be made automatically when you bump the ";; Version: NNN" commentary header in this repository, as I do in this commit. NonGNU ELPA does not look at any "git tag". In the future, you can bump the package version in that header (thereby releasing a new version) when you think it makes sense and at your convenience.

The rules for accepting a package into NonGNU ELPA are here, for your reference:
https://git.savannah.gnu.org/cgit/emacs/nongnu.git/tree/README.org#n133

As far as I can tell, this package already follows the rules so there should be nothing more to do with regards to that. However, it would be good if you could review them and let us know if you think there will be any problems with following any of them going forward. They should be straightforward and easy to follow, but note in particular that NonGNU ELPA does not distribute any package that recommends proprietary software.

Please let me know if you have any questions about NonGNU ELPA.

Thanks!